### PR TITLE
Gyors update - Mechatro zalaegerszeg

### DIFF
--- a/json/programs/pe_mk_mechatronikai-mernok-zeg.json
+++ b/json/programs/pe_mk_mechatronikai-mernok-zeg.json
@@ -561,7 +561,7 @@
                "name":"Automatika",
                "credits":2,
                "prerequisites":[
-                  "ZEMKFOB2121I"
+                  "(ZEMKFOB2121I)"
                ]
             },
             {
@@ -569,7 +569,7 @@
                "name":"Gyártástervezés",
                "credits":3,
                "prerequisites":[
-                  "ZEMKFOB2121I"
+                  "(ZEMKFOB2121I)"
                ]
             },
             {


### PR DESCRIPTION
Kihagyott két zárójel miatt nem lehet felvenni két tárgyat a kellő félévben.